### PR TITLE
Changed "source" field in sublime provider

### DIFF
--- a/glua-scraper/provider/SublimeProvider.cs
+++ b/glua-scraper/provider/SublimeProvider.cs
@@ -19,7 +19,7 @@ namespace glua_scraper.provider
         {
             ob = new JObject
             {
-                {"source", "source.lua - keyword.control.lua - constant.language.lua - string"},
+                {"scope", "source.lua - keyword.control.lua - constant.language.lua - string"},
                 {"completions", new JArray("in", "else", "return", "false", "true", "break", "or", "and")}
             };
 


### PR DESCRIPTION
This was my mistake originally.

The field name is supposed to be called "scope". Calling it "source" made those completions work everywhere, even in non-Lua files.
http://sublimetext.info/docs/en/extensibility/completions.html

https://github.com/FPtje/Sublime-GLua-Highlight/issues/16
